### PR TITLE
Add Shim for wp_body_open (fixes #65)

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -265,6 +265,16 @@ function aino_fonts_url() {
 	return esc_url_raw( $fonts_url );
 }
 
+if ( ! function_exists( 'wp_body_open' ) ) {
+
+	/**
+	 * Shim for wp_body_open, ensuring backwards compatibility with versions of WordPress older than 5.2.
+	 */
+	function wp_body_open() {
+		do_action( 'wp_body_open' );
+	}
+}
+
 /**
  * Include a skip to content link at the top of the page so that users can bypass the menu.
  */


### PR DESCRIPTION
Add Shim for wp_body_open, ensuring backwards compatibility with versions of WordPress older than 5.2.