### PR TITLE
add footer menu, added footer styles

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -22,6 +22,8 @@
 
 		<?php get_template_part( 'template-parts/footer/site', 'info' ); ?>
 
+		<?php get_template_part( 'template-parts/footer/footer', 'menu' ); ?>
+
 		</div>
 
 		</div><!-- .footer-wrap -->

--- a/template-parts/footer/footer-menu.php
+++ b/template-parts/footer/footer-menu.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Displays footer social menu if assigned
+ *
+ * @package Aino
+ */
+
+?>
+
+<?php
+if ( has_nav_menu( 'footer-menu' ) ) :
+	?>
+
+	<?php if ( has_nav_menu( 'footer-menu' ) ) : ?>
+
+		<nav id="footer-menu-nav" class="footer-menu-nav footer-nav" role="navigation" aria-label="<?php esc_attr_e( 'Footer Menu', 'aino' ); ?>">
+		<?php
+			wp_nav_menu(
+				array(
+					'theme_location'  => 'footer-menu',
+					'menu_class'      => 'footer-menu',
+					'container_class' => 'menu-footer-container',
+				)
+			);
+		?>
+		</nav><!-- .footer-social-nav -->
+
+	<?php endif; ?>
+
+<?php endif; ?>
+
+<?php
+if ( function_exists( 'the_privacy_policy_link' ) ) {
+	the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
+}
+?>

--- a/template-parts/footer/site-info.php
+++ b/template-parts/footer/site-info.php
@@ -21,19 +21,6 @@
 				<a class="site-name" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a>
 			<?php endif; ?>
 
-			<a href="<?php echo esc_url( __( 'https://wpaino.com', 'aino' ) ); ?>" class="imprint">
-				<?php
-				/* translators: %s: theme name */
-				printf( esc_html__( 'Powered by %s.', 'aino' ), 'Aino' );
-				?>
-			</a>
-
 		<?php endif; ?>
-
-		<?php
-		if ( function_exists( 'the_privacy_policy_link' ) ) {
-			the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
-		}
-		?>
 
 </div><!-- end .site-info -->


### PR DESCRIPTION
Branch adds a footer menu + styles. 

Idea: in Germany not only the "Privacy Policy" has to be visible inside the footer, also the link to "Impressum" has to be visible. From the Design perspective, it is nice, if those two links stands together. 

Also in the case, you want to add more links like "contact, support, AGB ..." it would be good, if this is not an extra menu in the widget area. Therefore I have registrered a footer menu and tried to place and style it next to the "privacy policy" link. 