### PR TITLE
Fixing blockquote hover color in block editor

### DIFF
--- a/inc/customizer/customizer-editor.php
+++ b/inc/customizer/customizer-editor.php
@@ -21,7 +21,7 @@ function aino_editor_customizer_generated_values() {
 		background-color: ' . esc_attr( $main_bg_color ) . ';
 	}
 	.editor-styles-wrapper p a:hover,
-	.editor-styles-wrapper blockquote:not(.has-text-color):hover,
+	.editor-styles-wrapper blockquote:not(.has-text-color) .wp-block-pullquote__citation a:hover,
 	.wp-block-pullquote__citation a:hover {
 		color: ' . esc_attr( $primary_one_color ) . ';
 		fill: ' . esc_attr( $primary_one_color ) . ';


### PR DESCRIPTION
It was probably not intended that the complete text of a blockquote in the block editor takes the `$primary_one_color` on hover, but only the links in the blockquote.